### PR TITLE
Fix link search path.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -44,7 +44,12 @@ fn main() {
         println!("cargo:rustc-link-lib=tbb");
     }
 
-    println!("cargo:rustc-link-search=native={}/lib", dst.display());
+    for dir in ["lib", "lib64"] {
+        let path = dst.join(dir);
+        if path.exists() {
+            println!("cargo:rustc-link-search=native={}", path.display());
+        }
+    }
     println!("cargo:rustc-link-lib={}=manifold", if feature_static() { "static" } else { "dylib" });
     println!("cargo:rustc-link-lib={}=manifoldc", if feature_static() { "static" } else { "dylib" });
 


### PR DESCRIPTION
This pull request updates the `build.rs` file to enhance compatibility with different library directory structures. The change modifies the logic for specifying library search paths, ensuring both `lib` and `lib64` directories are checked for existence before being added to the search path.

Key change in build logic:

* [`build.rs`](diffhunk://#diff-d0d98998092552a1d3259338c2c71e118a5b8343dd4703c0c7f552ada7f9cb42L47-R52): Replaced the single `lib` directory search path with a loop that checks both `lib` and `lib64` directories for existence, adding them to the library search path only if they exist. This improves compatibility with systems that use `lib64` for 64-bit libraries.